### PR TITLE
fix: exclude tag/category/list pages from pagefind search index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,53 @@ const pagefindRef = useRef<PagefindInstance | null>(null)
 
 ## ツールの利用
 
-### gh
+### gh コマンド
 
-- -R owner/repo フラグが必要です。
+このリポジトリでは git remote がプロキシ経由（`http://local_proxy@127.0.0.1:...`）で設定されているため、gh コマンドがデフォルトで GitHub ホストを検出できない。
+
+そのため、**必ず `-R owner/repo` フラグでリポジトリを明示的に指定する**こと。
+
+```bash
+# ❌ エラーになる
+gh pr create --title "..."
+
+# ✅ 正しい使い方
+gh pr create -R t-skgm/march-am-site --title "..."
+```
+
+## タスク完了後のフロー
+
+依頼されたタスクが完了したら、以下のフローでPRを作成する:
+
+1. **コミット前チェック**
+   ```bash
+   pnpm typecheck
+   pnpm lint
+   ```
+
+2. **変更をコミット**
+   ```bash
+   git add <変更ファイル>
+   git commit -m "fix/feat: 変更内容の要約"
+   ```
+
+3. **ブランチをプッシュ**
+   ```bash
+   git push -u origin <ブランチ名>
+   ```
+
+4. **PRを作成**
+   ```bash
+   gh pr create -R t-skgm/march-am-site --head <ブランチ名> --title "..." --body "..."
+   ```
+
+### PR本文のテンプレート
+
+```markdown
+## Summary
+- 変更内容を箇条書きで説明
+
+## Test plan
+- [ ] テスト項目1
+- [ ] テスト項目2
+```

--- a/src/components/CategoryPage.astro
+++ b/src/components/CategoryPage.astro
@@ -25,6 +25,7 @@ const title = `Category: ${category} (page ${page.currentPage})`
   canonicalPath={isIndexPage != null
     ? routes.article.category.page(category.toString(), 1)
     : undefined}
+  noPagefindIndex
 >
   <Main>
     <h1>{title}</h1>

--- a/src/components/TagPage.astro
+++ b/src/components/TagPage.astro
@@ -22,6 +22,7 @@ const title = `Tag: ${tag} (page ${page.currentPage})`
 <Layout
   title={title}
   canonicalPath={isIndexPage != null ? routes.article.tag.page(tag.toString(), 1) : undefined}
+  noPagefindIndex
 >
   <Main>
     <h1>{title}</h1>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,9 +19,11 @@ export interface Props {
   canonicalPath?: string | undefined
   overrideSEOProps?: Partial<SEOProps>
   socialImageURL?: string | undefined
+  /** pagefindのインデックス対象から除外する場合true */
+  noPagefindIndex?: boolean
 }
 
-const { isTop = false, title, frontmatter, canonicalPath, overrideSEOProps } = Astro.props
+const { isTop = false, title, frontmatter, canonicalPath, overrideSEOProps, noPagefindIndex = false } = Astro.props
 
 const articleTitle = (title ?? frontmatter?.title) as string | undefined
 const pageTitle = (divider: string) =>
@@ -88,7 +90,7 @@ const socialImageURL: string = (() => {
     <Logo />
     <SearchModal client:load />
     <!-- <Header /> -->
-    <div class:list={['content', { 'content-top': isTop }]} data-pagefind-body>
+    <div class:list={['content', { 'content-top': isTop }]} data-pagefind-body={!noPagefindIndex || undefined}>
       <slot />
     </div>
     <Footer isTop={isTop} />

--- a/src/pages/article/category/index.astro
+++ b/src/pages/article/category/index.astro
@@ -11,7 +11,7 @@ const categories = await fetchArticleCategories()
 const title = 'Category: All'
 ---
 
-<Layout title={title}>
+<Layout title={title} noPagefindIndex>
   <Main backTo={routes.article.index}>
     <h1>{title}</h1>
     <ul>

--- a/src/pages/article/index.astro
+++ b/src/pages/article/index.astro
@@ -12,7 +12,7 @@ const firstPage = await fetchArticlesFirstPage()
 const title = 'Article: All'
 ---
 
-<Layout title={title}>
+<Layout title={title} noPagefindIndex>
   <Main>
     <h1>{title}</h1>
     <ArticleList entries={firstPage.data} fullwidth />

--- a/src/pages/article/page/[page].astro
+++ b/src/pages/article/page/[page].astro
@@ -26,7 +26,7 @@ const { page, isIndexPage } = Astro.props
 const title = `Article - ${Astro.params.page === undefined ? 'All' : `page ${page.currentPage}`}`
 ---
 
-<Layout title={title} canonicalPath={isIndexPage != null ? routes.article.page(1) : undefined}>
+<Layout title={title} canonicalPath={isIndexPage != null ? routes.article.page(1) : undefined} noPagefindIndex>
   <Main>
     <h1>{title}</h1>
     <ArticleList entries={page.data} fullwidth />

--- a/src/pages/article/tag/index.astro
+++ b/src/pages/article/tag/index.astro
@@ -11,7 +11,7 @@ const allTags = await fetchArticleTags()
 const title = 'Tag: All'
 ---
 
-<Layout title={title}>
+<Layout title={title} noPagefindIndex>
   <Main backTo={routes.article.index}>
     <h1>{title}</h1>
     <ul>


### PR DESCRIPTION
## Summary
- pagefindの検索結果にタグページ、カテゴリーページ、記事一覧ページが表示されてしまう問題を修正
- `Layout.astro` に `noPagefindIndex` プロパティを追加し、`data-pagefind-body` 属性を条件付きで制御
- 一覧系ページすべてに `noPagefindIndex` を適用し、個別記事ページのみが検索結果に表示されるように

## Test plan
- [ ] `pnpm build` でビルドが成功することを確認
- [ ] 検索機能でタグ・カテゴリー・一覧ページが表示されないことを確認
- [ ] 個別記事ページは検索結果に表示されることを確認